### PR TITLE
fix: Remove duplicate consent questions from survey flow

### DIFF
--- a/client/src/pages/Survey/utils/survey.json
+++ b/client/src/pages/Survey/utils/survey.json
@@ -26,40 +26,8 @@
       ]
     },
     {
-      "name": "consent",
-      "title": "Consent Confirmation",
-      "elements": [
-        {
-          "type": "html",
-          "name": "consent-note",
-          "html": "<div><strong>Please read the following consent information out loud to the respondent and have them orally give their consent to you:</strong></div>\n            <br />\n<p>As part of work with the King County Regional Homelessness Authority (KCRHA), I'd like to ask you some questions we're required to ask and collect for our funders about unsheltered homelessness in our region.</p>\n<p>Your participation is voluntary and will not affect any services you or your family are seeking or currently receiving. We are surveying many people and will put all responses together, so it will not be possible to identify you from the information you provide here.</p>\n<p>As a token of appreciation for your time, we will give you a $20 preloaded debit card, $40 for families with minor children at the end.</p>\n<p>Would you be willing to talk with me for about 30 min?</p>"
-        },
-        {
-          "type": "radiogroup",
-          "name": "consent_given",
-          "title": "Do you consent to participate in this survey?",
-          "isRequired": true,
-          "choices": [
-            "Yes",
-            "No"
-          ]
-        },
-        {
-          "type": "radiogroup",
-          "name": "is_adult",
-          "title": "Are you 18 years old or older?",
-          "isRequired": true,
-          "choices": [
-            "Yes",
-            "No"
-          ]
-        }
-      ]
-    },
-    {
       "name": "qualtrics-survey",
       "title": "Main Survey",
-      "visibleIf": "{consent_given} = 'Yes' and {is_adult} = 'Yes'",
       "elements": [
         {
           "type": "html",


### PR DESCRIPTION
## 📄 Description

Removed consent questions (consent_given and is_adult) from the SurveyJS survey.json file since these questions are now being asked on the Qualtrics side. This eliminates duplication and streamlines the survey flow.

**Changes:**
- Removed consent page with consent_given and is_adult questions from survey.json
- Updated qualtrics-survey page visibility condition to remove consent dependencies

## ✅ Checklist

- [x] Tests added/updated where needed (manual testing completed)
- [x] Docs added/updated if applicable
- [ ] I have linked the issue this PR closes (if any)

## 💡 Type of change

| Type             | Checked? |
| ---------------- | -------- |
| 🐞 Bug fix       | [ ]      |
| ✨ New feature   | [ ]      |
| 📝 Documentation | [ ]      |
| ♻️ Refactor      | [x]      |
| 🛠️ Build/CI      | [ ]      |
| Other (explain)  | [ ]      |

## 🧪 How to test

1. Start the application and navigate to survey creation
2. Complete pre-screening (select location)
3. Verify that the Qualtrics iframe loads immediately after pre-screening
4. Confirm consent questions are handled within Qualtrics survey
5. Complete the survey flow and verify QR code generation works

## 📝 Notes to reviewers

This change removes 32 lines from survey.json - specifically the consent page that asked for consent_given and is_adult confirmation. Since these questions are now part of the Qualtrics survey itself, keeping them in SurveyJS was redundant and created a poor user experience (asking the same questions twice).